### PR TITLE
Updated for poly solve 11538

### DIFF
--- a/sympy/polys/constructor.py
+++ b/sympy/polys/constructor.py
@@ -9,6 +9,7 @@ from sympy.polys.domains import ZZ, QQ, RR, EX
 from sympy.polys.domains.realfield import RealField
 from sympy.utilities import public
 from sympy.core import sympify
+from sympy.core import NumberSymbol
 
 
 def _construct_simple(coeffs, opt):
@@ -122,8 +123,12 @@ def _construct_composite(coeffs, opt):
         return None
 
     if opt.composite is None:
-        if any(gen.is_number for gen in gens):
-            return None # generators are number-like so lets better use EX
+        for gen in gens:
+            if gen.is_number:
+                if isinstance(gen, NumberSymbol) and not gen.is_algebraic:
+                    continue
+                # generators are number-like so lets better use EX
+                return None
 
         all_symbols = set([])
 

--- a/sympy/polys/tests/test_constructor.py
+++ b/sympy/polys/tests/test_constructor.py
@@ -4,7 +4,7 @@ from sympy.polys.constructor import construct_domain
 from sympy.polys.domains import ZZ, QQ, RR, EX
 from sympy.polys.domains.realfield import RealField
 
-from sympy import S, sqrt, sin, Float
+from sympy import S, sqrt, sin, Float, E, GoldenRatio, pi, Catalan
 from sympy.abc import x, y
 
 def test_construct_domain():
@@ -121,3 +121,18 @@ def test_precision():
     result = construct_domain([f2])
     y = result[1][0]
     assert y-1 > 1e-50
+
+def test_issue_11538():
+    dom = ZZ[E]
+    assert construct_domain(E) == (dom, dom.convert(E))
+    dom = ZZ[x,E]
+    assert construct_domain(x**2 + 2*x + E) == \
+           (dom, dom.convert(x**2 + 2*x + E))
+    dom = ZZ[pi]
+    assert construct_domain(pi) == (dom, dom.convert(pi))
+    dom = ZZ[y,pi]
+    assert construct_domain(y**2 + pi) == \
+           (dom, dom.convert(y**2 + pi))
+    dom = EX
+    assert construct_domain(x + y + GoldenRatio) == \
+           (dom, dom.convert(x + y + GoldenRatio))

--- a/sympy/solvers/tests/test_solvers.py
+++ b/sympy/solvers/tests/test_solvers.py
@@ -4,7 +4,8 @@ from sympy import (
     Wild, acos, asin, atan, atanh, cos, cosh, diff, erf, erfinv, erfc,
     erfcinv, exp, im, log, pi, re, sec, sin,
     sinh, solve, solve_linear, sqrt, sstr, symbols, sympify, tan, tanh,
-    root, simplify, atan2, arg, Mul, SparseMatrix, ask, Tuple, nsolve, oo)
+    root, simplify, atan2, arg, Mul, SparseMatrix, ask, Tuple, nsolve, oo,
+    E, cbrt)
 
 from sympy.core.compatibility import range
 from sympy.core.function import nfloat
@@ -1792,3 +1793,17 @@ def test_issue_2840_8155():
 
 def test_issue_9567():
     assert solve(1 + 1/(x - 1)) == [0]
+
+def test_issue_11538():
+    assert solve(x + E) == [-E]
+    assert solve(x**2 + E) == [-I*sqrt(E), I*sqrt(E)]
+    assert solve(x**3 + 2*E) == [
+        -cbrt(2 * E),
+        cbrt(2)*cbrt(E)/2 - cbrt(2)*sqrt(3)*I*cbrt(E)/2,
+        cbrt(2)*cbrt(E)/2 + cbrt(2)*sqrt(3)*I*cbrt(E)/2]
+    assert solve([x + 4,y + E],x,y) == {x:-4,y:-E}
+    assert solve([x**2 + 4,y + E],x,y) == [(-2*I, -E), (2*I, -E)]
+
+    e1 = x - y**3 + 4
+    e2 = x + y + 4 + 4 * E
+    assert solve([e1,e2],x,y) != []

--- a/sympy/solvers/tests/test_solveset.py
+++ b/sympy/solvers/tests/test_solveset.py
@@ -697,7 +697,7 @@ def test_solveset_complex_exp():
 def test_solve_complex_log():
     assert solveset_complex(log(x), x) == FiniteSet(1)
     assert solveset_complex(1 - log(a + 4*x**2), x) == \
-        FiniteSet(-sqrt(-a/4 + E/4), sqrt(-a/4 + E/4))
+        FiniteSet(-sqrt(-a + E)/2, sqrt(-a + E)/2)
 
 
 def test_solve_complex_sqrt():


### PR DESCRIPTION
Updated constructor to treat NumberSymbols as symbols. polys containing non-algebraic number symbols are now treated as ZZ. This allows solvers to solve polynomials containing these specialized constants. 

Tests created were checked against WA. A test that ensures an empty set is not produced when given the original issue parameters was also produced. The non-empty set is hard to check against WA and contains tuples that need to be solved. 

A test was updated for test_solveset because the solver method now simplifies the output even further than was originally asserted.